### PR TITLE
AIOD-268: Default value use & index reorder

### DIFF
--- a/src/ai_on_demand/inference/inference_widget.py
+++ b/src/ai_on_demand/inference/inference_widget.py
@@ -508,10 +508,10 @@ Run segmentation/inference on selected images using one of the available pre-tra
                 # TODO: Check DHW orientation? Does Napari enforce this?
                 if label_layer.ndim == 3:
                     label_layer.data[
-                        start_z:end_z, start_x:end_x, start_y:end_y
+                        start_z:end_z, start_y:end_y, start_x:end_x
                     ] = mask_arr
                 else:
-                    label_layer.data[start_x:end_x, start_y:end_y] = mask_arr
+                    label_layer.data[start_y:end_y, start_x:end_x] = mask_arr
             label_layer.visible = True
             # Try to rearrange the layers to get them on top
             idxs = []

--- a/src/ai_on_demand/inference/model_selection.py
+++ b/src/ai_on_demand/inference/model_selection.py
@@ -416,6 +416,9 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
             elif isinstance(param_values, list):
                 param_val_widget = QComboBox()
                 param_val_widget.addItems([str(i) for i in param_values])
+                if model_param.default is not None:
+                    default_idx = param_values.index(model_param.default)
+                    param_val_widget.setCurrentIndex(default_idx)
                 param_val_widget.currentIndexChanged.connect(
                     self.on_param_changed
                 )


### PR DESCRIPTION
- Uses the default value in the schema if provided to select that default in a `QComboBox`
- Reorder the indices when loading masks (needed due to the fix made in https://github.com/FrancisCrickInstitute/Segment-Flow/pull/7)