### PR TITLE
Channel selection and axes reordering | AIOD-280

### DIFF
--- a/src/ai_on_demand/inference/data_selection.py
+++ b/src/ai_on_demand/inference/data_selection.py
@@ -7,12 +7,14 @@ from napari.layers import Image, Layer
 from napari.qt.threading import thread_worker
 import numpy as np
 import qtpy.QtCore
+from bioio_base.dimensions import Dimensions
 from qtpy.QtWidgets import (
     QWidget,
     QLayout,
     QGridLayout,
     QPushButton,
     QLabel,
+    QLineEdit,
     QFileDialog,
 )
 import pandas as pd
@@ -110,6 +112,39 @@ Images can also be opened, or dragged into napari as normal. The selection will 
         self.img_counts = QLabel(self.init_file_msg)
         self.img_counts.setWordWrap(True)
         self.inner_layout.addWidget(self.img_counts, 1, 0, 1, 3)
+
+        # Axis override row
+        axes_label = QLabel("Axes override:")
+        axes_label.setToolTip(
+            format_tooltip(
+                "Manually specify the axis order of loaded images (e.g. ZCYX, CZYX, ZYX). "
+                "Use this when the file has no axis metadata and the channel dropdown shows wrong values. "
+                "Letters: T=time, Z=depth, C=channel, Y=height, X=width, S=RGB samples."
+            )
+        )
+        self.axes_override_edit = QLineEdit()
+        self.axes_override_edit.setPlaceholderText("e.g. ZCYX  (blank = auto)")
+        self.axes_override_edit.setToolTip(
+            format_tooltip(
+                "Enter axis letters matching the number of image dimensions. "
+                "Leave blank to let bioio determine axes automatically."
+            )
+        )
+        self.axes_override_btn = QPushButton("Apply")
+        self.axes_override_btn.setToolTip(
+            format_tooltip(
+                "Apply the axes override to all currently loaded image layers "
+                "whose number of dimensions matches the length of the axes string."
+            )
+        )
+        self.axes_override_btn.clicked.connect(self.on_apply_axes_override)
+        self.inner_layout.addWidget(axes_label, 2, 0)
+        self.inner_layout.addWidget(self.axes_override_edit, 2, 1)
+        self.inner_layout.addWidget(self.axes_override_btn, 2, 2)
+        # Feedback label showing detected dimensions after override
+        self.axes_feedback_label = QLabel("")
+        self.axes_feedback_label.setWordWrap(True)
+        self.inner_layout.addWidget(self.axes_feedback_label, 3, 0, 1, 3)
 
         # Run the file counter if there are images already loaded
         if len(self.image_path_dict) > 0:
@@ -264,6 +299,74 @@ Images can also be opened, or dragged into napari as normal. The selection will 
         self.viewer.reset_view()
         # Signalling the images
         self.images_loaded.emit()
+        # Apply any pending axes override once images are loaded
+        if self.axes_override_edit.text().strip():
+            self.on_apply_axes_override()
+
+    def on_apply_axes_override(self):
+        """Apply a manually specified axis order to all loaded image layers.
+
+        Patches ``layer.metadata["dimensions"]`` so that channel/Z dropdowns
+        and ``get_img_dims()`` use the correct axis mapping without reloading
+        the image data.
+        """
+        axes = self.axes_override_edit.text().strip().upper()
+        if not axes:
+            return
+        # Validate: only known bioio axis letters
+        valid_letters = set("TCZYXS")
+        invalid = set(axes) - valid_letters
+        if invalid:
+            from napari.utils.notifications import show_error
+
+            show_error(
+                f"Invalid axis letters: {', '.join(sorted(invalid))}. "
+                "Use letters from T, C, Z, Y, X, S only."
+            )
+            return
+        if len(axes) != len(set(axes)):
+            from napari.utils.notifications import show_error
+
+            show_error("Duplicate axis letters in override string.")
+            return
+
+        patched = 0
+        feedback_dims = None
+        for layer in self.viewer.layers:
+            if not isinstance(layer, Image):
+                continue
+            if layer.data.ndim != len(axes):
+                continue
+            new_dims = Dimensions(axes, layer.data.shape)
+            layer.metadata["dimensions"] = new_dims
+            if feedback_dims is None:
+                feedback_dims = new_dims
+            patched += 1
+
+        if patched == 0:
+            from napari.utils.notifications import show_info
+
+            show_info(
+                f"No image layers with {len(axes)} dimensions found to apply '{axes}' to."
+            )
+            return
+
+        # Show detected dimensions as feedback
+        if feedback_dims is not None:
+            parts = []
+            for letter in axes:
+                val = getattr(feedback_dims, letter, None)
+                if val is not None:
+                    parts.append(f"{letter}={val}")
+            self.axes_feedback_label.setText(f"Detected: {', '.join(parts)}")
+
+        # Refresh channel dropdowns in model widget (if it exists)
+        if "model" in self.parent.subwidgets:
+            self.parent.subwidgets["model"]._refresh_all_channel_dropdowns()
+
+        from napari.utils.notifications import show_info
+
+        show_info(f"Applied axes '{axes}' to {patched} image layer(s).")
 
     def update_file_count(
         self, paths: Optional[list[Union[str, Path]]] = None

--- a/src/ai_on_demand/inference/inference_widget.py
+++ b/src/ai_on_demand/inference/inference_widget.py
@@ -1,25 +1,25 @@
-from pathlib import Path
 import time
+from pathlib import Path
 from typing import Optional, Union
 
+import aiod_utils.preprocess
+import aiod_utils.rle as aiod_rle
 import napari
-from napari.qt.threading import thread_worker
 import numpy as np
+from aiod_utils.io import extract_idxs_from_fname
+from napari.qt.threading import thread_worker
 
 from ai_on_demand.inference import (
-    TaskWidget,
+    ConfigWidget,
     DataWidget,
     ExportWidget,
     ModelWidget,
     NxfWidget,
     PreprocessWidget,
-    ConfigWidget,
+    TaskWidget,
 )
+from ai_on_demand.utils import calc_param_hash, get_img_dims
 from ai_on_demand.widget_classes import MainWidget
-from ai_on_demand.utils import calc_param_hash
-import aiod_utils.preprocess
-from aiod_utils.io import extract_idxs_from_fname
-import aiod_utils.rle as aiod_rle
 
 
 class Inference(MainWidget):
@@ -211,42 +211,15 @@ Run segmentation/inference on selected images using one of the available pre-tra
                     )
             else:
                 # If the associated image is present, use its shape
-                # Get ndim of the layer (this accounts for RGB)
                 img_layer = self.viewer.layers[f"{fpath.stem}"]
-                ndim = img_layer.ndim
                 metadata = img_layer.metadata
-                # Channels (non-RGB) & Z
-                # TODO: Switch to using utils.get_img_dims
-                if ndim == 4:
-                    # Channels should be first, don't care for labels so remove
-                    img_shape = img_layer.data.shape[1:]
-                elif ndim == 3:
-                    # If we have a Z, no problem
-                    if ("bioio_dims" in metadata) and (
-                        metadata["bioio_dims"].Z > 1
-                    ):
-                        img_shape = self.viewer.layers[
-                            f"{fpath.stem}"
-                        ].data.shape
-                    # Otherwise not loaded with bioio, so handle as Napari interprets
-                    else:
-                        # If RGB, then 2D RGB image
-                        # NOTE: This does not handle multi-channel 2D images
-                        if img_layer.rgb:
-                            img_shape = self.viewer.layers[
-                                f"{fpath.stem}"
-                            ].data.shape[1:]
-                        # Otherwise it's 3D single-channel image
-                        else:
-                            img_shape = self.viewer.layers[
-                                f"{fpath.stem}"
-                            ].data.shape
-                # Otherwise take the 2D image shape
-                # NOTE: [:ndim] is to handle RGB images as Napari interprets
+                H, W, num_slices, _ = get_img_dims(
+                    img_layer, fpath, verbose=False
+                )
+                if num_slices > 1:
+                    img_shape = (num_slices, H, W)
                 else:
-                    img_shape = self.viewer.layers[f"{fpath.stem}"].data.shape[
-                        :ndim
-                    ]
+                    img_shape = (H, W)
                 if prep_options is not None:
                     # Check if downsampling
                     metadata = {}
@@ -496,16 +469,23 @@ Run segmentation/inference on selected images using one of the available pre-tra
                     break
             label_layer = self.viewer.layers[mask_layer_name]
             # Insert mask data
-            # Check if dims match
             if label_layer.ndim != mask_arr.ndim:
+                # Try squeezing singleton dimensions (e.g. a single-Z-slice chunk
+                # whose Z axis was dropped by the model)
                 mask_arr = np.squeeze(mask_arr)
-                assert (
-                    label_layer.ndim == mask_arr.ndim
-                ), f"Mask appears to be {mask_arr.ndim}D (after squeezing), but layer is {label_layer.ndim}D"
-                label_layer.data = mask_arr
+                if label_layer.ndim != mask_arr.ndim:
+                    raise ValueError(
+                        f"Mask is {mask_arr.ndim}D after squeezing singleton dims, "
+                        f"but label layer is {label_layer.ndim}D; cannot insert chunk."
+                    )
+                # Squeezed away a singleton Z: insert the 2D slice at the right Z position
+                if label_layer.ndim == 3:
+                    label_layer.data[start_z, start_x:end_x, start_y:end_y] = (
+                        mask_arr
+                    )
+                else:
+                    label_layer.data[start_x:end_x, start_y:end_y] = mask_arr
             else:
-                # TODO: Handle multi-channel images
-                # TODO: Check DHW orientation? Does Napari enforce this?
                 if label_layer.ndim == 3:
                     label_layer.data[
                         start_z:end_z, start_x:end_x, start_y:end_y
@@ -525,8 +505,9 @@ Run segmentation/inference on selected images using one of the available pre-tra
             label_idx = self.viewer.layers.index(label_layer)
             idxs.append(label_idx)
             self.viewer.layers.move_multiple(idxs, -1)
-            # Switch viewer to latest slice
-            self.viewer.dims.set_point(0, end_z - 1)
+            # Switch viewer to latest slice (only meaningful for 3D)
+            if label_layer.ndim == 3:
+                self.viewer.dims.set_point(0, end_z - 1)
             # Insert the slice number into tracker for the progress bar
             self.subwidgets["nxf"].progress_dict[img_name] += 1
         # Now update the total progress bar

--- a/src/ai_on_demand/inference/inference_widget.py
+++ b/src/ai_on_demand/inference/inference_widget.py
@@ -480,18 +480,18 @@ Run segmentation/inference on selected images using one of the available pre-tra
                     )
                 # Squeezed away a singleton Z: insert the 2D slice at the right Z position
                 if label_layer.ndim == 3:
-                    label_layer.data[start_z, start_x:end_x, start_y:end_y] = (
+                    label_layer.data[start_z, start_y:end_y, start_x:end_x] = (
                         mask_arr
                     )
                 else:
-                    label_layer.data[start_x:end_x, start_y:end_y] = mask_arr
+                    label_layer.data[start_y:end_y, start_x:end_x] = mask_arr
             else:
                 if label_layer.ndim == 3:
                     label_layer.data[
-                        start_z:end_z, start_x:end_x, start_y:end_y
+                        start_z:end_z, start_y:end_y, start_x:end_x
                     ] = mask_arr
                 else:
-                    label_layer.data[start_x:end_x, start_y:end_y] = mask_arr
+                    label_layer.data[start_y:end_y, start_x:end_x] = mask_arr
             label_layer.visible = True
             # Try to rearrange the layers to get them on top
             idxs = []

--- a/src/ai_on_demand/inference/inference_widget.py
+++ b/src/ai_on_demand/inference/inference_widget.py
@@ -454,7 +454,7 @@ Run segmentation/inference on selected images using one of the available pre-tra
         # Add the extension
         return f"{mask_root}.{extension}"
 
-    def _reset_viewer(self):
+    def _reset_viewer(self, return_value=None):
         """
         Should help alleviate rendering issue where masks are mis-aligned.
 

--- a/src/ai_on_demand/inference/inference_widget.py
+++ b/src/ai_on_demand/inference/inference_widget.py
@@ -209,6 +209,14 @@ Run segmentation/inference on selected images using one of the available pre-tra
                 )
                 if downsample_factor is not None:
                     metadata["downsample_factor"] = downsample_factor
+                # Expand the mask to match the image's full ndim by inserting
+                # singleton dims at non-spatial positions (e.g. ZYX → ZCYX
+                # gives (Z,Y,X) → (Z,1,Y,X)) so napari aligns axes correctly.
+                mask_data = self._expand_mask_to_img_dims(
+                    mask_data, img_layer, img_metadata
+                )
+                # After expansion, ndim matches img_layer, so use its scale directly.
+                mask_scale = img_layer.scale
                 # Check if the mask layer already exists
                 if layer_name in self.viewer.layers:
                     # If so, update the data just to make sure & ensure visible
@@ -223,43 +231,50 @@ Run segmentation/inference on selected images using one of the available pre-tra
                         visible=True,
                         opacity=0.5,
                         metadata=metadata,
-                        scale=img_layer.scale
+                        scale=mask_scale
                         * metadata.get("downsample_factor", 1.0),
                     )
             else:
                 # If the associated image is present, use its shape
                 # Get ndim of the layer (this accounts for RGB)
                 ndim = img_layer.ndim
-                # Channels (non-RGB) & Z
-                # TODO: Switch to using utils.get_img_dims
-                if ndim == 4:
-                    # Channels should be first, don't care for labels so remove
+                # Fetch axes metadata early; used for both img_shape and
+                # mask_scale so that any ordering (CZYX, ZCYX, ZYX, CYX, YX,
+                # …) is handled correctly without positional assumptions.
+                _dims = img_metadata.get("dimensions", None)
+                _spatial = frozenset("ZYX")
+                # Determine the spatial-only shape for the mask placeholder.
+                # Instance segmentation models return spatial-only outputs
+                # even when the input has one or more channel dimensions.
+                if _dims is not None and hasattr(_dims, "order"):
+                    # Use the recorded axes order to pick spatial dims exactly,
+                    # regardless of where C (or T) sits in the array.
+                    img_shape = tuple(
+                        s
+                        for d, s in zip(_dims.order, img_layer.data.shape)
+                        if d in _spatial
+                    )
+                elif img_layer.rgb:
+                    # Napari represents RGB images with the colour channel as
+                    # the last axis (Y, X, 3) or (Z, Y, X, 3); drop it.
+                    img_shape = img_layer.data.shape[:-1]
+                elif ndim >= 4:
+                    # No axes metadata and ≥4-D: strip the leading axis as a
+                    # best-effort guess (most likely C or T at position 0).
                     img_shape = img_layer.data.shape[1:]
                 elif ndim == 3:
-                    # If we have a Z, no problem
                     if ("bioio_dims" in img_metadata) and (
                         img_metadata["bioio_dims"].Z > 1
                     ):
-                        img_shape = self.viewer.layers[
-                            f"{fpath.stem}"
-                        ].data.shape
-                    # Otherwise not loaded with bioio, so handle as Napari interprets
+                        # bioio confirmed Z > 1, so all three dims are spatial
+                        img_shape = img_layer.data.shape
                     else:
-                        # If RGB, then 2D RGB image
-                        # NOTE: This does not handle multi-channel 2D images
-                        if img_layer.rgb:
-                            img_shape = self.viewer.layers[
-                                f"{fpath.stem}"
-                            ].data.shape[1:]
-                        # Otherwise it's 3D single-channel image
-                        else:
-                            img_shape = self.viewer.layers[
-                                f"{fpath.stem}"
-                            ].data.shape
-                # Otherwise take the 2D image shape
-                # NOTE: [:ndim] is to handle RGB images as Napari interprets
+                        # Cannot distinguish C from Z without axes metadata;
+                        # conservatively strip the leading axis.
+                        img_shape = img_layer.data.shape[1:]
                 else:
-                    img_shape = (H, W)
+                    # 2D (Y, X)
+                    img_shape = img_layer.data.shape
                 if prep_options is not None:
                     # Check if downsampling
                     downsample_factor = (
@@ -277,7 +292,23 @@ Run segmentation/inference on selected images using one of the available pre-tra
                     )
                 else:
                     mask_shape = img_shape
+                # Expand the spatial-only mask shape to match the image's full
+                # ndim by inserting size-1 dims at non-spatial axis positions
+                # (e.g. (Z,Y,X) → (Z,1,Y,X) for ZCYX), so napari aligns axes
+                # correctly instead of padding from the left with trailing-dim logic.
+                if (
+                    _dims is not None
+                    and hasattr(_dims, "order")
+                    and not img_layer.rgb
+                ):
+                    expanded = list(mask_shape)
+                    for pos, dim_char in enumerate(_dims.order):
+                        if dim_char not in _spatial:
+                            expanded.insert(pos, 1)
+                    mask_shape = tuple(expanded)
                 img_metadata["img_scale"] = img_layer.scale
+                # After expansion mask_shape has the same ndim as img_layer.scale.
+                mask_scale = img_layer.scale
                 # Add a Labels layer for this file
                 self.viewer.add_labels(
                     np.zeros(mask_shape, dtype=np.uint16),
@@ -285,7 +316,7 @@ Run segmentation/inference on selected images using one of the available pre-tra
                     visible=False,
                     opacity=0.5,
                     metadata=img_metadata,
-                    scale=img_layer.scale,
+                    scale=mask_scale,
                 )
             # Now move the new layer to be just above the image layer, ensuring they group together
             self.viewer.layers.move(
@@ -508,6 +539,45 @@ Run segmentation/inference on selected images using one of the available pre-tra
         # Add the extension
         return f"{mask_root}.{extension}"
 
+    def _expand_mask_to_img_dims(
+        self,
+        mask_arr: np.ndarray,
+        img_layer,
+        img_metadata: dict,
+    ) -> np.ndarray:
+        """Expand a spatial-only mask to match the full ndim of the image layer.
+
+        Inserts singleton dimensions at the positions of non-spatial axes using
+        the axes order recorded in ``img_metadata["dimensions"].order``.
+
+        Example: ZYX mask (75, 75, 75) + ZCYX image → (75, 1, 75, 75), so that
+        napari aligns the Z slider correctly rather than using trailing-dim padding
+        which would map the mask's Z axis onto the image's C axis.
+
+        The invariant that makes the sequential insertion work: when processing
+        position ``pos`` in the axes order string, the array has exactly ``pos``
+        axes (one contributed per position already handled, whether spatial or
+        inserted-singleton), so ``np.expand_dims(arr, axis=pos)`` always places
+        the new singleton at the correct absolute position in the final array.
+
+        Returns the mask unchanged when axes metadata is unavailable, when the
+        mask already matches the image ndim, or for RGB images.
+        """
+        _dims = img_metadata.get("dimensions", None)
+        _spatial = frozenset("ZYX")
+        if (
+            img_layer.rgb
+            or _dims is None
+            or not hasattr(_dims, "order")
+            or mask_arr.ndim >= img_layer.ndim
+        ):
+            return mask_arr
+        result = mask_arr
+        for pos, dim_char in enumerate(_dims.order):
+            if dim_char not in _spatial:
+                result = np.expand_dims(result, axis=pos)
+        return result
+
     def _reset_viewer(self, return_value=None):
         """
         Should help alleviate rendering issue where masks are mis-aligned.
@@ -549,16 +619,35 @@ Run segmentation/inference on selected images using one of the available pre-tra
                     img_name = d["img_path"].stem
                     break
             label_layer = self.viewer.layers[mask_layer_name]
-            # On first mask for this layer, check if shape matches model output and recreate if not
-            if not label_layer.visible and label_layer.ndim != mask_arr.ndim:
-                correct_shape = tuple(
-                    s for s in label_layer.data.shape if s > 1
+            # Expand the spatial-only mask slice to match the image's full ndim
+            # (e.g. (nz,ny,nx) → (nz,1,ny,nx) for a ZCYX image) so the
+            # assignment index and the array shape are consistent.
+            _img_layer_ref = (
+                self.viewer.layers[img_name]
+                if img_name in self.viewer.layers
+                else None
+            )
+            _img_layer_meta = (
+                (_img_layer_ref.metadata or {})
+                if _img_layer_ref is not None
+                else {}
+            )
+            if _img_layer_ref is not None:
+                mask_arr = self._expand_mask_to_img_dims(
+                    mask_arr, _img_layer_ref, _img_layer_meta
                 )
+            _dims_meta = _img_layer_meta.get("dimensions", None)
+            _spatial = frozenset("ZYX")
+            # On first mask for this layer, check if shape matches model output and recreate if not.
+            if (
+                not label_layer.visible
+                and label_layer.data.shape != mask_arr.shape
+            ):
                 layer_idx = self.viewer.layers.index(label_layer)
                 layer_meta = label_layer.metadata
                 self.viewer.layers.remove(label_layer)
                 label_layer = self.viewer.add_labels(
-                    np.zeros(correct_shape, dtype=np.uint16),
+                    np.zeros(mask_arr.shape, dtype=np.uint16),
                     name=mask_layer_name,
                     visible=False,
                     opacity=0.5,
@@ -567,19 +656,33 @@ Run segmentation/inference on selected images using one of the available pre-tra
                 self.viewer.layers.move(
                     self.viewer.layers.index(mask_layer_name), layer_idx
                 )
-            # Insert mask data
-            if label_layer.ndim != mask_arr.ndim:
-                # Fallback: shouldn't happen after recreation, but guard anyway
-                mask_arr = np.squeeze(mask_arr)
-            if label_layer.ndim == mask_arr.ndim:
-                # TODO: Handle multi-channel images
-                # TODO: Check DHW orientation? Does Napari enforce this?
-                if label_layer.ndim == 3:
-                    label_layer.data[
-                        start_z:end_z, start_y:end_y, start_x:end_x
-                    ] = mask_arr
+            # Insert mask data using the correct per-axis index tuple so that
+            # non-spatial singleton dims are addressed with slice(None).
+            if label_layer.data.shape == mask_arr.shape:
+                if (
+                    _dims_meta is not None
+                    and hasattr(_dims_meta, "order")
+                    and label_layer.ndim == len(_dims_meta.order)
+                ):
+                    idx = tuple(
+                        slice(start_z, end_z)
+                        if d == "Z"
+                        else slice(start_y, end_y)
+                        if d == "Y"
+                        else slice(start_x, end_x)
+                        if d == "X"
+                        else slice(None)
+                        for d in _dims_meta.order
+                    )
+                elif label_layer.ndim >= 3:
+                    idx = (
+                        slice(start_z, end_z),
+                        slice(start_y, end_y),
+                        slice(start_x, end_x),
+                    )
                 else:
-                    label_layer.data[start_y:end_y, start_x:end_x] = mask_arr
+                    idx = (slice(start_y, end_y), slice(start_x, end_x))
+                label_layer.data[idx] = mask_arr
             label_layer.visible = True
             # Apply scale for downsampled masks, accounting for pixel size scaling if present
             downsample_factor = label_layer.metadata.get(
@@ -601,9 +704,18 @@ Run segmentation/inference on selected images using one of the available pre-tra
             label_idx = self.viewer.layers.index(label_layer)
             idxs.append(label_idx)
             self.viewer.layers.move_multiple(idxs, -1)
-            # Switch viewer to latest slice (only meaningful for 3D)
-            if label_layer.ndim == 3:
-                self.viewer.dims.set_point(0, end_z - 1)
+            # Switch viewer to latest Z slice, using the correct viewer dim for Z.
+            if end_z > start_z:
+                if (
+                    _dims_meta is not None
+                    and hasattr(_dims_meta, "order")
+                    and "Z" in _dims_meta.order
+                ):
+                    self.viewer.dims.set_point(
+                        _dims_meta.order.index("Z"), end_z - 1
+                    )
+                else:
+                    self.viewer.dims.set_point(0, end_z - 1)
             # Insert the slice number into tracker for the progress bar
             self.subwidgets["nxf"].progress_dict[img_name] += 1
         # Now update the total progress bar
@@ -638,8 +750,41 @@ Run segmentation/inference on selected images using one of the available pre-tra
                 preprocess_str=preprocess_str,
             )
             mask_arr, _ = self._load_mask_file(fpath)
+            # Expand to image ndim (e.g. ZYX → Z1YX for ZCYX) so napari aligns
+            # the mask's Z axis with the image's Z axis rather than its C axis.
+            _img_stem = img_dict["img_path"].stem
+            _img_layer_ref = (
+                self.viewer.layers[_img_stem]
+                if _img_stem in self.viewer.layers
+                else None
+            )
+            _img_layer_meta = (
+                (_img_layer_ref.metadata or {})
+                if _img_layer_ref is not None
+                else {}
+            )
+            if _img_layer_ref is not None:
+                mask_arr = self._expand_mask_to_img_dims(
+                    mask_arr, _img_layer_ref, _img_layer_meta
+                )
             # Insert mask data
             label_layer = self.viewer.layers[mask_layer_name]
+            # Recreate the layer if shape changed after expansion.
+            if label_layer.data.shape != mask_arr.shape:
+                layer_idx = self.viewer.layers.index(label_layer)
+                layer_meta = label_layer.metadata
+                layer_name_local = label_layer.name
+                self.viewer.layers.remove(label_layer)
+                label_layer = self.viewer.add_labels(
+                    np.zeros(mask_arr.shape, dtype=np.uint16),
+                    name=layer_name_local,
+                    visible=False,
+                    opacity=0.5,
+                    metadata=layer_meta,
+                )
+                self.viewer.layers.move(
+                    self.viewer.layers.index(layer_name_local), layer_idx
+                )
             label_layer.data = mask_arr
             label_layer.visible = True
             # Apply scale for downsampled masks, accounting for pixel size scaling if present

--- a/src/ai_on_demand/inference/mask_export.py
+++ b/src/ai_on_demand/inference/mask_export.py
@@ -101,7 +101,9 @@ class ExportWidget(SubWidget):
         """
         Binarises the given mask layer.
         """
-        return (mask_layer.data).astype(bool).astype(np.uint8) * 255
+        return (np.squeeze(mask_layer.data)).astype(bool).astype(
+            np.uint8
+        ) * 255
 
     def on_select_change(self, event):
         layers_selected = event.source
@@ -176,6 +178,10 @@ class ExportWidget(SubWidget):
                     fname += "_binarised"
                 else:
                     mask_data = mask_layer.data
+                # Squeeze out any singleton dimensions inserted for napari axis
+                # alignment (e.g. (Z,1,Y,X) → (Z,Y,X)) so exported files are
+                # spatial-only, matching the pipeline's original output format.
+                mask_data = np.squeeze(mask_data)
                 # Get the extension & add to fname
                 ext = (
                     self.export_format_dropdown.currentText()

--- a/src/ai_on_demand/inference/model_selection.py
+++ b/src/ai_on_demand/inference/model_selection.py
@@ -2,35 +2,32 @@ import builtins
 from pathlib import Path
 
 import napari
-from napari.utils.notifications import show_error
-from napari._qt.qt_resources import QColoredSVGIcon
-from qtpy.QtCore import Qt
-from qtpy.QtWidgets import (
-    QWidget,
-    QLayout,
-    QGridLayout,
-    QVBoxLayout,
-    QHBoxLayout,
-    QPushButton,
-    QFileDialog,
-    QLabel,
-    QLineEdit,
-    QComboBox,
-    QCheckBox,
-    QDialog,
-    QTextEdit,
-)
 import yaml
-
-from ai_on_demand.widget_classes import SubWidget
-from ai_on_demand.utils import (
-    format_tooltip,
-    sanitise_name,
-    merge_dicts,
-    calc_param_hash,
-    load_config_file,
-    InfoWindow
+from napari._qt.qt_resources import QColoredSVGIcon
+from napari.utils.notifications import show_error
+from qtpy.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QFileDialog,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLayout,
+    QLineEdit,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
 )
+
+from ai_on_demand.utils import (
+    InfoWindow,
+    calc_param_hash,
+    format_tooltip,
+    load_config_file,
+    merge_dicts,
+    sanitise_name,
+)
+from ai_on_demand.widget_classes import SubWidget
 
 
 class ModelWidget(SubWidget):
@@ -74,6 +71,8 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
         self.versions_per_task = {}
         # Dict of model params for each model version, specific to each task
         self.model_version_tasks = {}
+        # Dict to store full ModelVersion objects for accessing metadata like axes
+        self.model_versions = {}
 
         # Extract the model info from all manifests
         for model_manifest in self.parent.all_manifests.values():
@@ -92,13 +91,13 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
                     if base_name not in self.versions_per_task[task_name]:
                         self.versions_per_task[task_name][base_name] = []
                     # Add this version, for this base model, under this task
-                    self.versions_per_task[task_name][base_name].append(
-                        version_name
-                    )
+                    self.versions_per_task[task_name][base_name].append(version_name)
                     # Store this model-version-task for easy access to params and config
-                    self.model_version_tasks[
-                        (task_name, base_name, version_name)
-                    ] = task
+                    self.model_version_tasks[(task_name, base_name, version_name)] = (
+                        task
+                    )
+                    # Store the full ModelVersion for accessing metadata
+                    self.model_versions[(task_name, base_name, version_name)] = version
 
     def create_box(self, variant: str | None = None):
         # TODO: This will have to become a variant for e.g. fine-tuning
@@ -126,9 +125,7 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
         )
         self.model_version_dropdown = QComboBox()
         self.model_version_dropdown.addItems(["Select a model first!"])
-        self.model_version_dropdown.activated.connect(
-            self.on_model_version_select
-        )
+        self.model_version_dropdown.activated.connect(self.on_model_version_select)
         model_box_layout.addWidget(model_version_label, 1, 0)
         model_box_layout.addWidget(self.model_version_dropdown, 1, 1, 1, 2)
 
@@ -219,9 +216,7 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
             self.parent.selected_model
         ]
         self.model_version_dropdown.addItems(model_versions)
-        self.parent.selected_variant = (
-            self.model_version_dropdown.currentText()
-        )
+        self.parent.selected_variant = self.model_version_dropdown.currentText()
         # Update the model params & config widgets for the selected model
         self.update_model_param_config(
             self.parent.selected_model, self.parent.selected_variant
@@ -229,9 +224,7 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
 
     def on_model_version_select(self):
         # Update tracker for selected model variant/version
-        self.parent.selected_variant = (
-            self.model_version_dropdown.currentText()
-        )
+        self.parent.selected_variant = self.model_version_dropdown.currentText()
         # Update the model params & config widgets for the selected model variant/version
         self.update_model_param_config(
             self.parent.selected_model, self.parent.selected_variant
@@ -334,6 +327,10 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
         # Stores user-loaded config paths for models with no UI params,
         # keyed by (task, model, version) tuple
         self.user_config_path: dict[tuple, Path] = {}
+        # Track all channel QComboBoxes so they can be refreshed when layers change
+        self._channel_widgets: list[QComboBox] = []
+        self.viewer.layers.events.inserted.connect(self._refresh_all_channel_dropdowns)
+        self.viewer.layers.events.removed.connect(self._refresh_all_channel_dropdowns)
         # Disable showing widget until selected to view
         self.model_param_widget.setVisible(False)
         self.inner_layout.addWidget(self.model_param_widget)
@@ -374,9 +371,7 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
             ]
         # If no parameters, use the no_param widget
         elif param_list is None:
-            self.curr_model_param_widget = self.model_param_widgets_dict[
-                "no_param"
-            ]
+            self.curr_model_param_widget = self.model_param_widgets_dict["no_param"]
         # Otherwise, construct it
         else:
             self.curr_model_param_widget = self._create_model_params_widget(
@@ -408,8 +403,23 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
             # Add the model parameter(s)
             param_values = model_param.value
             # Widget added depends on the input
+            # Channel selector -> image-aware ComboBox
+            if getattr(model_param, "type", None) == "channel":
+                param_val_widget = QComboBox()
+                param_val_widget.setProperty("param_type", "channel")
+                channel_names = self._get_channel_names()
+                param_val_widget.addItems(channel_names)
+                default_idx = (
+                    param_values
+                    if isinstance(param_values, int)
+                    and param_values < len(channel_names)
+                    else 0
+                )
+                param_val_widget.setCurrentIndex(default_idx)
+                param_val_widget.currentIndexChanged.connect(self.on_param_changed)
+                self._channel_widgets.append(param_val_widget)
             # True/False -> Checkbox
-            if param_values is True or param_values is False:
+            elif param_values is True or param_values is False:
                 param_val_widget = QCheckBox()
                 # Checked if default param value is True, unchecked if False
                 if param_values:
@@ -421,14 +431,9 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
             elif isinstance(param_values, list):
                 param_val_widget = QComboBox()
                 param_val_widget.addItems([str(i) for i in param_values])
-                param_val_widget.currentIndexChanged.connect(
-                    self.on_param_changed
-                )
+                param_val_widget.currentIndexChanged.connect(self.on_param_changed)
             # Int/float/str/None -> LineEdit
-            elif (
-                isinstance(param_values, (int, float, str))
-                or param_values is None
-            ):
+            elif isinstance(param_values, (int, float, str)) or param_values is None:
                 param_val_widget = QLineEdit()
                 param_val_widget.setText(str(param_values))
                 param_val_widget.textChanged.connect(self.on_param_changed)
@@ -451,14 +456,49 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
     def on_param_changed(self):
         self.changed_defaults = True
 
+    def _get_channel_names(self) -> list[str]:
+        """Return channel labels derived from the first Image layer in the viewer."""
+        layers = [
+            layer
+            for layer in self.viewer.layers
+            if isinstance(layer, napari.layers.Image)
+        ]
+        if not layers:
+            return ["0 (grayscale)"]
+        layer = layers[0]
+        dims = layer.metadata.get("dimensions")
+        n_channels = None
+        if dims is not None:
+            if hasattr(dims, "C") and dims.C is not None and dims.C > 1:
+                n_channels = dims.C
+            elif layer.rgb and hasattr(dims, "S") and dims.S is not None and dims.S > 1:
+                n_channels = dims.S
+        if n_channels is None or n_channels <= 1:
+            return ["0 (grayscale)"]
+        channel_names = layer.metadata.get("channel_names")
+        if channel_names and len(channel_names) == n_channels:
+            return ["0 (grayscale)"] + [
+                f"{i + 1}: {name}" for i, name in enumerate(channel_names)
+            ]
+        return ["0 (grayscale)"] + [str(i + 1) for i in range(n_channels)]
+
+    def _refresh_all_channel_dropdowns(self, event=None):
+        """Repopulate all channel ComboBoxes when the layer list changes."""
+        channel_names = self._get_channel_names()
+        for combo in self._channel_widgets:
+            current_idx = combo.currentIndex()
+            combo.blockSignals(True)
+            combo.clear()
+            combo.addItems(channel_names)
+            combo.setCurrentIndex(min(current_idx, combo.count() - 1))
+            combo.blockSignals(False)
+
     def clear_model_param_widget(self):
         # Remove the current model param widget
         self.model_param_layout.removeWidget(self.curr_model_param_widget)
         self.curr_model_param_widget.setParent(None)
 
-    def set_model_param_widget(
-        self, task_model_version: tuple | None = None
-    ):
+    def set_model_param_widget(self, task_model_version: tuple | None = None):
         if task_model_version is not None:
             self.curr_model_param_widget = self.model_param_widgets_dict[
                 task_model_version
@@ -478,10 +518,7 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
         # Check that there is a model available for this task
         if task_name in self.versions_per_task:
             model_names = sorted(
-                [
-                    self.base_to_display[i]
-                    for i in self.versions_per_task[task_name]
-                ]
+                [self.base_to_display[i] for i in self.versions_per_task[task_name]]
             )
         else:
             model_names = [self.model_name_unavail]
@@ -501,7 +538,7 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
             "Select a model config",
             str(self.config_dir),
             "Configs (*.yaml *.yml *.json)",
-        ) # type: ignore
+        )  # type: ignore
         # Reset if dialog cancelled
         if fname == "":
             return
@@ -541,7 +578,9 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
                     f"Config '{model_config_path.name}' loaded into UI parameters."
                 )
             except KeyError as e:
-                show_error(f"Failed to load config '{config_path.name}': assumed input was a project config but no {e} key found!")
+                show_error(
+                    f"Failed to load config '{config_path.name}': assumed input was a project config but no {e} key found!"
+                )
                 self.model_config_label.setText("No model config file loaded.")
                 return
         except UserWarning as e:
@@ -604,9 +643,7 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
             else:
                 # No UI params: prefer user-loaded config, fall back to schema config
                 user_path = self.user_config_path.get(task_model_version)
-                model_dict = (
-                    load_config_file(user_path) if user_path else base_dict
-                )
+                model_dict = load_config_file(user_path) if user_path else base_dict
         else:
             if model_version.params is None:
                 # No schema and no UI params: must have a user-loaded config
@@ -637,9 +674,7 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
             yaml.dump(model_dict, f)
         return model_config_fpath
 
-    def create_config_params(
-        self, task_model_version: tuple | None = None
-    ) -> dict:
+    def create_config_params(self, task_model_version: tuple | None = None) -> dict:
         """
         Construct the model config from the parameter widgets.
 
@@ -651,8 +686,12 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
         model_dict_orig = self.model_param_dict[task_model_version]
         # Get the relevant default params for this model
         default_params = self.model_version_tasks[task_model_version].params
+        # Get the model version metadata
+        model_version = self.model_versions.get(task_model_version)
         # Reformat the dict to pipe into downstream model run scripts
         model_dict = {}
+        if model_version and model_version.axes is not None:
+            model_dict["axes"] = model_version.axes
         # Extract params from model param widgets
         for orig_param, (param_name, sub_dict) in zip(
             default_params, model_dict_orig.items()
@@ -662,7 +701,11 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
             if isinstance(sub_dict["value"], QLineEdit):
                 param_value = sub_dict["value"].text()
             elif isinstance(sub_dict["value"], QComboBox):
-                param_value = sub_dict["value"].currentText()
+                if sub_dict["value"].property("param_type") == "channel":
+                    # Channel ComboBox: the integer index is the value
+                    param_value = sub_dict["value"].currentIndex()
+                else:
+                    param_value = sub_dict["value"].currentText()
             elif isinstance(sub_dict["value"], QCheckBox):
                 param_value = sub_dict["value"].isChecked()
             else:
@@ -717,9 +760,14 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
             if isinstance(widget, QCheckBox):
                 widget.setChecked(bool(value))
             elif isinstance(widget, QComboBox):
-                idx = widget.findText(str(value))
-                if idx != -1:
-                    widget.setCurrentIndex(idx)
+                if widget.property("param_type") == "channel":
+                    # value is an integer channel index
+                    idx = int(value) if value is not None else 0
+                    widget.setCurrentIndex(min(idx, widget.count() - 1))
+                else:
+                    idx = widget.findText(str(value))
+                    if idx != -1:
+                        widget.setCurrentIndex(idx)
             elif isinstance(widget, QLineEdit):
                 widget.setText(str(value) if value is not None else "None")
             else:
@@ -744,9 +792,7 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
         gui_dict = self.create_config_params(task_model_version=task_model_version)
         return merge_dicts(config, gui_dict)
 
-    def get_task_model_variant(
-        self, executed: bool = True
-    ) -> tuple[str, str, str]:
+    def get_task_model_variant(self, executed: bool = True) -> tuple[str, str, str]:
         if executed:
             task, model, version = (
                 self.parent.executed_task,
@@ -775,9 +821,7 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
             raise ValueError(f"Model {model_name} not recognised.")
         model_index = self.model_dropdown.findText(model_display_name)
         if model_index == -1:
-            raise ValueError(
-                f"Model {model_name} not available for this task."
-            )
+            raise ValueError(f"Model {model_name} not available for this task.")
         self.model_dropdown.setCurrentIndex(model_index)
         self.on_model_select()
 
@@ -843,5 +887,7 @@ Version: {task_model_version[2]}
         if model_version.config_path is not None:
             model_info += f"\nConfig path: {model_version.config_path}"
 
-        self.model_window = InfoWindow(self, title="Model Information", content=model_info)
+        self.model_window = InfoWindow(
+            self, title="Model Information", content=model_info
+        )
         self.model_window.show()

--- a/src/ai_on_demand/inference/model_selection.py
+++ b/src/ai_on_demand/inference/model_selection.py
@@ -409,12 +409,18 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
                 param_val_widget.setProperty("param_type", "channel")
                 channel_names = self._get_channel_names()
                 param_val_widget.addItems(channel_names)
-                default_idx = (
-                    param_values
-                    if isinstance(param_values, int)
-                    and param_values < len(channel_names)
-                    else 0
+                param_val_widget.setToolTip(
+                    "Select channel for processing.\n"
+                    "-1: Use original image as-is\n"
+                    "0 to N-1: Extract specific channel by index"
                 )
+                # Set to the default from the manifest if it exists
+                # Manifest default is the channel integer (-1, 0, 1, ...)
+                # Map to dropdown index: -1 → 0, 0 → 1, 1 → 2, etc.
+                param_values = model_param.value
+                default_idx = 0
+                if param_values is not None:
+                    default_idx = param_values + 1  # channel int -> dropdown index
                 param_val_widget.setCurrentIndex(default_idx)
                 param_val_widget.currentIndexChanged.connect(self.on_param_changed)
                 self._channel_widgets.append(param_val_widget)
@@ -431,6 +437,16 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
             elif isinstance(param_values, list):
                 param_val_widget = QComboBox()
                 param_val_widget.addItems([str(i) for i in param_values])
+                if model_param.default is not None:
+                    default_list_idx = next(
+                        (
+                            j
+                            for j, v in enumerate(param_values)
+                            if v == model_param.default
+                        ),
+                        0,
+                    )
+                    param_val_widget.setCurrentIndex(default_list_idx)
                 param_val_widget.currentIndexChanged.connect(self.on_param_changed)
             # Int/float/str/None -> LineEdit
             elif isinstance(param_values, (int, float, str)) or param_values is None:
@@ -457,14 +473,19 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
         self.changed_defaults = True
 
     def _get_channel_names(self) -> list[str]:
-        """Return channel labels derived from the first Image layer in the viewer."""
+        """Return channel labels derived from the first Image layer in the viewer.
+
+        Returns -1 (original image) followed by 0-indexed channel selections.
+        For single-channel or no image: ["-1 (original)", "0"]
+        For multi-channel: ["-1 (original)", "0", "1", ...] or ["-1 (original)", "0: name", "1: name", ...]
+        """
         layers = [
             layer
             for layer in self.viewer.layers
             if isinstance(layer, napari.layers.Image)
         ]
         if not layers:
-            return ["0 (grayscale)"]
+            return ["-1 (original)", "0"]
         layer = layers[0]
         dims = layer.metadata.get("dimensions")
         n_channels = None
@@ -474,13 +495,13 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
             elif layer.rgb and hasattr(dims, "S") and dims.S is not None and dims.S > 1:
                 n_channels = dims.S
         if n_channels is None or n_channels <= 1:
-            return ["0 (grayscale)"]
+            return ["-1 (original)", "0"]
         channel_names = layer.metadata.get("channel_names")
         if channel_names and len(channel_names) == n_channels:
-            return ["0 (grayscale)"] + [
-                f"{i + 1}: {name}" for i, name in enumerate(channel_names)
+            return ["-1 (original)"] + [
+                f"{i}: {name}" for i, name in enumerate(channel_names)
             ]
-        return ["0 (grayscale)"] + [str(i + 1) for i in range(n_channels)]
+        return ["-1 (original)"] + [str(i) for i in range(n_channels)]
 
     def _refresh_all_channel_dropdowns(self, event=None):
         """Repopulate all channel ComboBoxes when the layer list changes."""
@@ -612,8 +633,21 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
             if isinstance(widget, QCheckBox):
                 widget.setChecked(bool(default))
             elif isinstance(widget, QComboBox):
-                # Default is the first item in the list
-                widget.setCurrentIndex(0)
+                # Channel params: map integer to dropdown index
+                if widget.property("param_type") == "channel":
+                    # Default is the channel integer (-1, 0, 1, ...)
+                    # Map to dropdown index: channel_int + 1
+                    default_channel = param.value if param.value is not None else -1
+                    default_idx = default_channel + 1
+                # List params: find matching value or use first
+                elif param.default is not None and isinstance(param.value, list):
+                    default_idx = next(
+                        (j for j, v in enumerate(param.value) if v == param.default),
+                        0,
+                    )
+                else:
+                    default_idx = 0
+                widget.setCurrentIndex(default_idx)
             elif isinstance(widget, QLineEdit):
                 widget.setText(str(default) if default is not None else "None")
         self.changed_defaults = False
@@ -702,8 +736,11 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
                 param_value = sub_dict["value"].text()
             elif isinstance(sub_dict["value"], QComboBox):
                 if sub_dict["value"].property("param_type") == "channel":
-                    # Channel ComboBox: the integer index is the value
-                    param_value = sub_dict["value"].currentIndex()
+                    # Channel ComboBox: parse the integer from the text
+                    # Format: "-1 (original)", "0", "1", or "0: name", "1: name"
+                    text = sub_dict["value"].currentText()
+                    # Extract the leading integer (handles "-1", "0", "0: name", etc.)
+                    param_value = int(text.split(":")[0].split()[0])
                 else:
                     param_value = sub_dict["value"].currentText()
             elif isinstance(sub_dict["value"], QCheckBox):

--- a/src/ai_on_demand/inference/model_selection.py
+++ b/src/ai_on_demand/inference/model_selection.py
@@ -407,20 +407,25 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
             if getattr(model_param, "type", None) == "channel":
                 param_val_widget = QComboBox()
                 param_val_widget.setProperty("param_type", "channel")
-                channel_names = self._get_channel_names()
+                ch_start = model_param.channel_start
+                ch_start_label = model_param.channel_start_label
+                param_val_widget.setProperty("channel_start", ch_start)
+                param_val_widget.setProperty("channel_start_label", ch_start_label)
+                channel_names = self._get_channel_names(ch_start, ch_start_label)
                 param_val_widget.addItems(channel_names)
                 param_val_widget.setToolTip(
-                    "Select channel for processing.\n"
-                    "-1: Use original image as-is\n"
-                    "0 to N-1: Extract specific channel by index"
+                    f"Select channel for processing.\n"
+                    f"{ch_start} ({ch_start_label}): model-specific default\n"
+                    f"{ch_start + 1} onward: image channel by index"
                 )
-                # Set to the default from the manifest if it exists
-                # Manifest default is the channel integer (-1, 0, 1, ...)
-                # Map to dropdown index: -1 → 0, 0 → 1, 1 → 2, etc.
+                # Set to the default from the manifest if it exists.
+                # Map manifest integer to dropdown index: value - channel_start
+                # e.g. StarDist (channel_start=-1): value=0 → index 1
+                # e.g. Cellpose  (channel_start=0):  value=1 → index 1
                 param_values = model_param.value
                 default_idx = 0
                 if param_values is not None:
-                    default_idx = param_values + 1  # channel int -> dropdown index
+                    default_idx = param_values - ch_start  # channel int -> dropdown index
                 param_val_widget.setCurrentIndex(default_idx)
                 param_val_widget.currentIndexChanged.connect(self.on_param_changed)
                 self._channel_widgets.append(param_val_widget)
@@ -472,20 +477,32 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
     def on_param_changed(self):
         self.changed_defaults = True
 
-    def _get_channel_names(self) -> list[str]:
-        """Return channel labels derived from the first Image layer in the viewer.
+    def _get_channel_names(
+        self, channel_start: int = -1, channel_start_label: str = "original"
+    ) -> list[str]:
+        """Return channel labels for a channel-type parameter dropdown.
 
-        Returns -1 (original image) followed by 0-indexed channel selections.
-        For single-channel or no image: ["-1 (original)", "0"]
-        For multi-channel: ["-1 (original)", "0", "1", ...] or ["-1 (original)", "0: name", "1: name", ...]
+        The first item is the model-specific starting value (e.g. ``-1 (original)``
+        for index-based models, or ``0 (Grayscale)`` for Cellpose). Subsequent items
+        represent actual image channels numbered from ``channel_start + 1``.
+
+        Args:
+            channel_start: Lowest integer value in the dropdown (default -1).
+            channel_start_label: Human-readable label for the first item (default "original").
+
+        Returns:
+            For single-channel/no image: ["<start> (<label>)", "<start+1>"]
+            For multi-channel: ["<start> (<label>)", "<start+1>", "<start+2>", ...]
+            Named channels: ["<start> (<label>)", "<start+1>: name", ...]
         """
+        start_item = f"{channel_start} ({channel_start_label})"
         layers = [
             layer
             for layer in self.viewer.layers
             if isinstance(layer, napari.layers.Image)
         ]
         if not layers:
-            return ["-1 (original)", "0"]
+            return [start_item, str(channel_start + 1)]
         layer = layers[0]
         dims = layer.metadata.get("dimensions")
         n_channels = None
@@ -495,18 +512,27 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
             elif layer.rgb and hasattr(dims, "S") and dims.S is not None and dims.S > 1:
                 n_channels = dims.S
         if n_channels is None or n_channels <= 1:
-            return ["-1 (original)", "0"]
+            return [start_item, str(channel_start + 1)]
         channel_names = layer.metadata.get("channel_names")
         if channel_names and len(channel_names) == n_channels:
-            return ["-1 (original)"] + [
-                f"{i}: {name}" for i, name in enumerate(channel_names)
+            return [start_item] + [
+                f"{channel_start + 1 + i}: {name}"
+                for i, name in enumerate(channel_names)
             ]
-        return ["-1 (original)"] + [str(i) for i in range(n_channels)]
+        return [start_item] + [
+            str(channel_start + 1 + i) for i in range(n_channels)
+        ]
 
     def _refresh_all_channel_dropdowns(self, event=None):
         """Repopulate all channel ComboBoxes when the layer list changes."""
-        channel_names = self._get_channel_names()
         for combo in self._channel_widgets:
+            ch_start = combo.property("channel_start")
+            ch_start_label = combo.property("channel_start_label")
+            if ch_start is None:
+                ch_start = -1
+            if ch_start_label is None:
+                ch_start_label = "original"
+            channel_names = self._get_channel_names(ch_start, ch_start_label)
             current_idx = combo.currentIndex()
             combo.blockSignals(True)
             combo.clear()

--- a/src/ai_on_demand/inference/model_selection.py
+++ b/src/ai_on_demand/inference/model_selection.py
@@ -404,7 +404,7 @@ Parameters can be modified if setup properly, otherwise a config file can be loa
             param_values = model_param.value
             # Widget added depends on the input
             # Channel selector -> image-aware ComboBox
-            if getattr(model_param, "type", None) == "channel":
+            if getattr(model_param, "param_type", None) == "channel":
                 param_val_widget = QComboBox()
                 param_val_widget.setProperty("param_type", "channel")
                 ch_start = model_param.channel_start

--- a/src/ai_on_demand/inference/nxf.py
+++ b/src/ai_on_demand/inference/nxf.py
@@ -1,38 +1,38 @@
-from os import environ
-from collections import defaultdict
-from pathlib import Path
+import re
 import shlex
 import shutil
 import subprocess
+from os import environ
+from pathlib import Path
 from typing import Optional, Union
-from urllib.parse import urlparse
-import re
 
-from aiod_registry import TASK_NAMES
+import aiod_utils.preprocess
 import napari
-from napari.qt.threading import thread_worker
-from napari.utils.notifications import show_info
-import pandas as pd
 import qtpy.QtCore
-from qtpy.QtWidgets import (
-    QWidget,
-    QLayout,
-    QGridLayout,
-    QHBoxLayout,
-    QVBoxLayout,
-    QLabel,
-    QComboBox,
-    QPushButton,
-    QFileDialog,
-    QProgressBar,
-    QCheckBox,
-    QSpinBox,
-    QDoubleSpinBox,
-    QGroupBox,
-    QMessageBox,
-)
 import tqdm
 import yaml
+from aiod_registry import TASK_NAMES
+from aiod_utils.io import image_paths_to_csv
+from aiod_utils.stacks import Stack, calc_num_stacks, generate_stack_indices
+from napari.qt.threading import thread_worker
+from napari.utils.notifications import show_info
+from qtpy.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDoubleSpinBox,
+    QFileDialog,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLayout,
+    QMessageBox,
+    QProgressBar,
+    QPushButton,
+    QSpinBox,
+    QVBoxLayout,
+    QWidget,
+)
 
 from ai_on_demand.utils import (
     InfoWindow,
@@ -41,9 +41,6 @@ from ai_on_demand.utils import (
     sanitise_name,
 )
 from ai_on_demand.widget_classes import SubWidget
-import aiod_utils.preprocess
-from aiod_utils.stacks import generate_stack_indices, calc_num_stacks, Stack
-from aiod_utils.io import image_paths_to_csv
 
 
 class NxfWidget(SubWidget):
@@ -61,13 +58,14 @@ class NxfWidget(SubWidget):
         layout: QLayout = QGridLayout,
         **kwargs,
     ):
-        # Define attributes that may be useful outside of this class
-        # or throughout it
-        self.nxf_repo = (
-            Path(environ["AIOD_NXF_REPO"])
-            if "AIOD_NXF_REPO" in environ
-            else "FrancisCrickInstitute/Segment-Flow"
-        )
+        # Define attributes that may be useful outside of this class or throughout it
+        _bundled = Path(__file__).parent.parent / "Segment-Flow"
+        if "AIOD_NXF_REPO" in environ:
+            self.nxf_repo = Path(environ["AIOD_NXF_REPO"])
+            self.nxf_profiles_dir = self.nxf_repo / "profiles"
+        else:
+            self.nxf_repo = "FrancisCrickInstitute/Segment-Flow"
+            self.nxf_profiles_dir = _bundled / "profiles"
         # Set the base Nextflow command
         self.setup_nxf_dir_cmd()
         super().__init__(
@@ -262,18 +260,14 @@ Note that 'opening' won't do anything, this is just to see what files are presen
             format_tooltip("Select the execution profile to use.")
         )
         self.nxf_profile_box = QComboBox()
-        # Get the available profiles from config dir
-        config_dir = Path(__file__).parent.parent / "Segment-Flow" / "profiles"
-        avail_confs = [str(i.stem) for i in config_dir.glob("*.conf")]
+        avail_confs = [str(i.stem) for i in self.nxf_profiles_dir.glob("*.conf")]
         avail_confs.sort()
         if len(avail_confs) == 0:
             raise FileNotFoundError(
-                f"No Nextflow profiles found in {config_dir}!"
+                f"No Nextflow profiles found in {self.nxf_profiles_dir}!"
             )
         self.nxf_profile_box.addItems(avail_confs)
-        self.nxf_profile_box.setFocusPolicy(
-            qtpy.QtCore.Qt.FocusPolicy.StrongFocus
-        )
+        self.nxf_profile_box.setFocusPolicy(qtpy.QtCore.Qt.FocusPolicy.StrongFocus)
         self.pipeline_layout.addWidget(self.nxf_profile_label, 0, 0)
         self.pipeline_layout.addWidget(self.nxf_profile_box, 0, 1)
 


### PR DESCRIPTION
Main changes:

- To avoid duplicating images solely to match expected input channels, this PR adds channel selection support to models. For example:
    - Cellpose 3 expects two channels, and users can now select `Segment Channel` and `Nucleus Channel` independently from dropdown menus.
    - StarDist and PlantSeg can be used to segment DAPI and boundaries in large multiplexed images, with both channels selectable directly in the UI.
    - Selecting `-1` preserves the original image shape.
- This PR also adds axes reordering to support correct channel-axis annotation. For example, the official Cellpose `rgb_3D.tif` is loaded without the correct axes annotation (`ZCYX`) in Napari, Fiji, and BioIO. In these cases, users need a way to override the detected axes order.

Minor fixes:

- Fix handling of `AIOD_NXF_REPO`, introduced in https://github.com/FrancisCrickInstitute/ai-on-demand/pull/17
- Complete adoption of `get_img_dims()`, introduced in https://github.com/FrancisCrickInstitute/ai-on-demand/pull/16

Related PRs: 

- https://github.com/FrancisCrickInstitute/Segment-Flow/pull/13
- https://github.com/FrancisCrickInstitute/AIoD-Model-Registry/pull/19

<img width="639" height="730" alt="CleanShot 2026-04-07 at 18 17 19" src="https://github.com/user-attachments/assets/21b6b463-23fb-4a73-b734-5e334b1a4d34" />
<img width="639" height="730" alt="CleanShot 2026-04-07 at 18 34 05" src="https://github.com/user-attachments/assets/8963fc68-c655-4bf8-9d3b-f6b934bedf68" />
