### PR TITLE
AIOD-295 fix all loaded

### DIFF
--- a/src/ai_on_demand/inference/data_selection.py
+++ b/src/ai_on_demand/inference/data_selection.py
@@ -315,12 +315,16 @@ Images can also be opened, or dragged into napari as normal. The selection will 
             self.viewer.layers.remove(layer)
 
     def get_config_params(self, params):
-        widget_config = {"img_dir": params.get("img_dir")}
-        return widget_config
+        img_dir = params.get("img_dir")
+        if img_dir is not None:
+            df = pd.read_csv(img_dir)
+            img_paths = df["img_path"].drop_duplicates().tolist()
+        else:
+            img_paths = []
+        return {"img_paths": img_paths}
 
     def load_config(self, config):
-        df = pd.read_csv(config["img_dir"])
-        img_paths = df["img_path"].tolist()
+        img_paths = config["img_paths"]
         self.update_file_count(paths=img_paths)
         self.view_images(imgs_to_load=img_paths)
 

--- a/src/ai_on_demand/inference/data_selection.py
+++ b/src/ai_on_demand/inference/data_selection.py
@@ -189,8 +189,6 @@ Images can also be opened, or dragged into napari as normal. The selection will 
         """
         Loads the selected images into napari for viewing (in separate threads).
         """
-        # Ensure Nextflow subwidget knows not all images are loaded until this func returns
-        self.parent.subwidgets["nxf"].all_loaded = False
         # Return if there's nothing to show
         if len(self.image_path_dict) == 0:
             return
@@ -218,6 +216,8 @@ Images can also be opened, or dragged into napari as normal. The selection will 
             return
         if len(imgs_to_load) == 0:
             return
+        # Ensure Nextflow subwidget knows not all images are loaded until loading completes
+        self.parent.subwidgets["nxf"].all_loaded = False
         # Reset counter
         self.load_img_counter = 0
 

--- a/src/ai_on_demand/inference/data_selection.py
+++ b/src/ai_on_demand/inference/data_selection.py
@@ -316,11 +316,15 @@ Images can also be opened, or dragged into napari as normal. The selection will 
 
     def get_config_params(self, params):
         img_dir = params.get("img_dir")
-        if img_dir is not None:
+        if img_dir is None:
+            return {"img_paths": []}
+        try:
             df = pd.read_csv(img_dir)
             img_paths = df["img_path"].drop_duplicates().tolist()
-        else:
-            img_paths = []
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to read image list from config (img_dir={img_dir})"
+            ) from e
         return {"img_paths": img_paths}
 
     def load_config(self, config):


### PR DESCRIPTION
- `all_loaded` flag moved to after early returns so it doesn't get stuck if the relevant images already loaded before project config selection
- extra bug fix: project config widget only saved the path to the all_images_csv, not the relevant image paths. This file gets overwritten on each run, so loading a project config would previously only load the images used for the most recent pipeline run, not those applicable to the saved project