### PR TITLE
AIOD-296 fix mask layer dims

### DIFF
--- a/src/ai_on_demand/inference/inference_widget.py
+++ b/src/ai_on_demand/inference/inference_widget.py
@@ -577,22 +577,8 @@ Run segmentation/inference on selected images using one of the available pre-tra
             mask_arr = aiod_rle.load_encoding(fpath)
             # NOTE: Mask metadata should be no different, so ignore
             mask_arr, _ = aiod_rle.decode(mask_arr)
-            # Insert mask data - recreate layer if shape doesn't match actual model output
+            # Insert mask data
             label_layer = self.viewer.layers[mask_layer_name]
-            if label_layer.data.shape != mask_arr.shape:
-                layer_idx = self.viewer.layers.index(label_layer)
-                layer_meta = label_layer.metadata
-                self.viewer.layers.remove(label_layer)
-                label_layer = self.viewer.add_labels(
-                    np.zeros(mask_arr.shape, dtype=np.uint16),
-                    name=mask_layer_name,
-                    visible=False,
-                    opacity=0.5,
-                    metadata=layer_meta,
-                )
-                self.viewer.layers.move(
-                    self.viewer.layers.index(mask_layer_name), layer_idx
-                )
             label_layer.data = mask_arr
             label_layer.visible = True
         # Now we'll sort all the layers, grouping together the image and mask layers for each image

--- a/src/ai_on_demand/inference/inference_widget.py
+++ b/src/ai_on_demand/inference/inference_widget.py
@@ -495,15 +495,27 @@ Run segmentation/inference on selected images using one of the available pre-tra
                     img_name = d["img_path"].stem
                     break
             label_layer = self.viewer.layers[mask_layer_name]
+            # On first mask for this layer, check if shape matches model output and recreate if not
+            if not label_layer.visible and label_layer.ndim != mask_arr.ndim:
+                correct_shape = tuple(s for s in label_layer.data.shape if s > 1)
+                layer_idx = self.viewer.layers.index(label_layer)
+                layer_meta = label_layer.metadata
+                self.viewer.layers.remove(label_layer)
+                label_layer = self.viewer.add_labels(
+                    np.zeros(correct_shape, dtype=np.uint16),
+                    name=mask_layer_name,
+                    visible=False,
+                    opacity=0.5,
+                    metadata=layer_meta,
+                )
+                self.viewer.layers.move(
+                    self.viewer.layers.index(mask_layer_name), layer_idx
+                )
             # Insert mask data
-            # Check if dims match
             if label_layer.ndim != mask_arr.ndim:
+                # Fallback: shouldn't happen after recreation, but guard anyway
                 mask_arr = np.squeeze(mask_arr)
-                assert (
-                    label_layer.ndim == mask_arr.ndim
-                ), f"Mask appears to be {mask_arr.ndim}D (after squeezing), but layer is {label_layer.ndim}D"
-                label_layer.data = mask_arr
-            else:
+            if label_layer.ndim == mask_arr.ndim:
                 # TODO: Handle multi-channel images
                 # TODO: Check DHW orientation? Does Napari enforce this?
                 if label_layer.ndim == 3:
@@ -565,9 +577,24 @@ Run segmentation/inference on selected images using one of the available pre-tra
             mask_arr = aiod_rle.load_encoding(fpath)
             # NOTE: Mask metadata should be no different, so ignore
             mask_arr, _ = aiod_rle.decode(mask_arr)
-            # Insert mask data
-            self.viewer.layers[mask_layer_name].data = mask_arr
-            self.viewer.layers[mask_layer_name].visible = True
+            # Insert mask data - recreate layer if shape doesn't match actual model output
+            label_layer = self.viewer.layers[mask_layer_name]
+            if label_layer.data.shape != mask_arr.shape:
+                layer_idx = self.viewer.layers.index(label_layer)
+                layer_meta = label_layer.metadata
+                self.viewer.layers.remove(label_layer)
+                label_layer = self.viewer.add_labels(
+                    np.zeros(mask_arr.shape, dtype=np.uint16),
+                    name=mask_layer_name,
+                    visible=False,
+                    opacity=0.5,
+                    metadata=layer_meta,
+                )
+                self.viewer.layers.move(
+                    self.viewer.layers.index(mask_layer_name), layer_idx
+                )
+            label_layer.data = mask_arr
+            label_layer.visible = True
         # Now we'll sort all the layers, grouping together the image and mask layers for each image
         # Get the image layer names
         image_layers = sorted(


### PR DESCRIPTION
**problem**: Mask layers are created with dimensions guessed from the input image. (`inference_widget.py:create_mask_layers()`)
https://github.com/FrancisCrickInstitute/ai-on-demand/blob/871b007e5bb4dd63e1e37ec0ff6ae635f6587d55/src/ai_on_demand/inference/inference_widget.py#L213-L223
Breaking scenario: Image with dims `(1,1,H,W)` (as in the AIOD sample FIBSEM image) creates a mask layer with dims `(1,H,W)`. 
A model (e.g. SAM) might squeeze the input image before processing and output a (H,W) mask, resulting in a dim mismatch when inserting the intermediate results in `update_masks()`) (there is a squeeze guard, which only handles the case when `mask.ndim > layer.ndim` not the other way round.

https://github.com/FrancisCrickInstitute/ai-on-demand/blob/9542b8eae9b577f0783a386d7784c4b6e57b1cc0/src/ai_on_demand/inference/inference_widget.py#L498-L505

This fix checks recreates the mask layer with a new shape on receiving the intermediate results if they don't match. It's fine for now

**However**, a more robust rewrite/rethink of `create_mask_layers` is needed (see also outstanding [TODO](https://github.com/FrancisCrickInstitute/ai-on-demand/blob/871b007e5bb4dd63e1e37ec0ff6ae635f6587d55/src/ai_on_demand/inference/inference_widget.py#L219)) to avoid further issues with guessing what mask dimensions the model will produce. (e.g. it isn't inconceivable that a model might take multi-channel input and output multi-channel masks).