### PR TITLE
AIOD-309 Clean up downsample handling

### DIFF
--- a/src/ai_on_demand/inference/inference_widget.py
+++ b/src/ai_on_demand/inference/inference_widget.py
@@ -18,6 +18,7 @@ from ai_on_demand.inference import (
 from ai_on_demand.widget_classes import MainWidget
 from ai_on_demand.utils import calc_param_hash
 import aiod_utils.preprocess
+from aiod_utils.stacks import stack_to_shape
 from aiod_utils.io import extract_idxs_from_fname
 import aiod_utils.rle as aiod_rle
 
@@ -258,8 +259,11 @@ Run segmentation/inference on selected images using one of the available pre-tra
                     )
                     if downsample_factor is not None:
                         metadata["downsample_factor"] = downsample_factor
-                    mask_shape = aiod_utils.preprocess.get_output_shape(
-                        options=prep_options, input_shape=img_shape
+                    mask_shape = stack_to_shape(
+                        aiod_utils.preprocess.get_output_shape(
+                            options=prep_options, input_shape=img_shape
+                        ),
+                        ndim=len(img_shape),
                     )
                 else:
                     mask_shape = img_shape

--- a/src/ai_on_demand/inference/inference_widget.py
+++ b/src/ai_on_demand/inference/inference_widget.py
@@ -262,7 +262,7 @@ Run segmentation/inference on selected images using one of the available pre-tra
                         )
                     )
                     if downsample_factor is not None:
-                        metadata["downsample_factor"] = downsample_factor
+                        img_metadata["downsample_factor"] = downsample_factor
                     mask_shape = stack_to_shape(
                         aiod_utils.preprocess.get_output_shape(
                             options=prep_options, input_shape=img_shape

--- a/src/ai_on_demand/inference/nxf.py
+++ b/src/ai_on_demand/inference/nxf.py
@@ -570,14 +570,9 @@ Threshold for the Intersection over Union (IoU) metric used in the SAM post-proc
                     )
                 else:
                     output_shape = aiod_utils.preprocess.get_output_shape(
-                        d["prep_set"], input_shape=(num_slices, H, W)
+                        d["prep_set"], input_shape=Stack(height=H, width=W, depth=num_slices)
                     )
-                    final_shape = Stack(
-                        height=output_shape[1],
-                        width=output_shape[2],
-                        depth=output_shape[0],
-                        channels=channels,
-                    )
+                    final_shape = output_shape._replace(channels=channels)
                 # Calculate the number of substacks
                 num_substacks, eff_shape = calc_num_stacks(
                     image_shape=final_shape,

--- a/src/ai_on_demand/inference/preprocess.py
+++ b/src/ai_on_demand/inference/preprocess.py
@@ -267,9 +267,6 @@ Rescale mask layers to raw data size (if downsampled). Helps visually compare wi
                             show_info(
                                 f"Changed Filter footprint to {option['params']['footprint']} from {footprint} for 2D preview."
                             )
-                    elif option["name"] == "Downsample":
-                        # block_size is always (D, H, W); Downsample.run handles 2D images
-                        pass
             else:
                 image = data
         else:

--- a/src/ai_on_demand/inference/preprocess.py
+++ b/src/ai_on_demand/inference/preprocess.py
@@ -268,12 +268,8 @@ Rescale mask layers to raw data size (if downsampled). Helps visually compare wi
                                 f"Changed Filter footprint to {option['params']['footprint']} from {footprint} for 2D preview."
                             )
                     elif option["name"] == "Downsample":
-                        blocksize = option["params"]["block_size"]
-                        if len(blocksize) == 3:
-                            option["params"]["block_size"] = blocksize[1:]
-                            show_info(
-                                f"Changed Downsample blocksize to {option['params']['block_size']} from {blocksize} for 2D preview."
-                            )
+                        # block_size is always (D, H, W); Downsample.run handles 2D images
+                        pass
             else:
                 image = data
         else:
@@ -313,7 +309,7 @@ Rescale mask layers to raw data size (if downsampled). Helps visually compare wi
         for layer in mask_layers:
             blocksize = layer.metadata.get("downsample_factor", None)
             if blocksize is not None:
-                layer.scale = blocksize
+                layer.scale = blocksize[-layer.ndim:]
 
     def extract_options(self):
         # Shortcut for when no postprocessing has been done


### PR DESCRIPTION
- use Stack from aiod_utils.stacks to represent downsample dimensions where practical and for mask dims
- block size kept 3 dimensional (indexing should adapt to final layer shape where needed)

Conflicts with AIOD-307 #34 