### PR TITLE
AIOD-323: Hash mismatch with preprocessing sets/UI

### DIFF
--- a/src/aiod_napari/inference/preprocess.py
+++ b/src/aiod_napari/inference/preprocess.py
@@ -155,15 +155,11 @@ Any preprocessing applied here is for visualization purposes only, only the orig
         self.prep_run_btn.clicked.connect(
             partial(self.on_click_run, run_on_slice=False)
         )
-        self.prep_run_btn.setToolTip(
-            format_tooltip(
-                """
+        self.prep_run_btn.setToolTip(format_tooltip("""
 Apply the selected preprocessing options to the entire stack of the currently selected image (or first image layer if none selected).
 NOTE: This will run the computation locally and return an array in-memory, so be careful with larger images and/or expensive preprocessing.
 NOTE: The result is just for visualization! Only the original image will be used in the Nextflow pipeline.
-                """
-            )
-        )
+                """))
         self.btn_layout.addWidget(self.prep_run_btn, 0, 1, 1, 1)
         # Add some draft buttons for preprocessing sets
         self.save_set_btn = QPushButton("Save preprocessing set")
@@ -457,6 +453,35 @@ NOTE: The result is just for visualization! Only the original image will be used
             self.preprocess_sets = []
         self._update_viewsets_btn()
         self._reset_preprocess()
+        if config and len(config) == 1:
+            # Single non-empty set: reflect it in the UI so the user can see
+            self._load_options_into_ui(config[0])
+            self.preprocess_sets = []
+            self._update_viewsets_btn()
+
+    def _load_options_into_ui(self, options: list[dict]):
+        """Populate the UI checkboxes and parameter widgets from a single preprocessing set."""
+        self.order_list = []
+        for step in options:
+            name = step["name"]
+            params = step["params"]
+            self.preprocess_boxes[name]["box"].setChecked(True)
+            for param_name, value in params.items():
+                widget = self.preprocess_boxes[name]["params"][param_name]
+                if isinstance(widget, QCheckBox):
+                    widget.setChecked(bool(value))
+                elif isinstance(widget, QComboBox):
+                    idx = widget.findText(str(value))
+                    if idx != -1:
+                        widget.setCurrentIndex(idx)
+                elif isinstance(widget, QLineEdit):
+                    if isinstance(value, (list, tuple)):
+                        widget.setText(", ".join(map(str, value)))
+                    else:
+                        widget.setText(str(value))
+            self.order_list.append(name)
+        if self.order_list:
+            self.preprocess_order.setText("->".join(self.order_list))
 
 
 class PreprocessSetWindow(QDialog):

--- a/src/aiod_napari/utils.py
+++ b/src/aiod_napari/utils.py
@@ -80,7 +80,7 @@ def filter_empty_dict(d: dict) -> dict:
 def calc_param_hash(d: dict) -> str:
     # Sort the dictionary so that the hash is consistent on contents rather than order
     sorted_d = dict(sorted(d.items()))
-    return hashlib.md5(json.dumps(sorted_d).encode("utf-8")).hexdigest()
+    return hashlib.md5(json.dumps(sorted_d, sort_keys=True).encode("utf-8")).hexdigest()
 
 
 def load_config_file(config_path: str | Path) -> dict:


### PR DESCRIPTION
The issue wasn't due to different UI and saved sets. 
We are already saving the ui the same as we would sets in a list
https://github.com/FrancisCrickInstitute/aiod_napari/blob/6441d5e59671e108e667f437bed268fec69dd857/src/aiod_napari/inference/preprocess.py#L354

The issue is in how we are saving the config files. Using yaml.dump to save our config files sorts by keys. So when values are loaded from the config file the dictionary ends up in a different order in calc_param_hash

We resolve this by sorting by keys before getting the hash.

This will mean previous users won't have matching hashes to whatever is in their cache currently. But there's no nice solution to that and I don't think it matters they can just run the pipeline again.

